### PR TITLE
Replace deploy_to with release_path so that the Gemfile will be found by bundler

### DIFF
--- a/lib/capistrano-deploy/bundle.rb
+++ b/lib/capistrano-deploy/bundle.rb
@@ -13,7 +13,7 @@ Capistrano::Configuration.instance(:must_exist).load do
       args = [bundle_flags.to_s]
       args << "--without #{bundle_without.join(' ')}" unless bundle_without.empty?
 
-      run "cd #{deploy_to} && #{bundle_cmd} install #{args.join(' ')}"
+      run "cd #{release_path} && #{bundle_cmd} install #{args.join(' ')}"
     end
   end
 end


### PR DESCRIPTION
When doing a cap deploy, it failed on bundler saying "Gemfile not found". I discovered that it was running bundler in the main deploy_to directory, rather in the actual release directory, so there was no Gemfile. This patch changes 'deploy_to' to 'release_path' so that bundler runs in the correct directory and finds the Gemfile.
