### PR TITLE
Allow unicorn:reexec to continue if pid file doesn't exist

### DIFF
--- a/lib/capistrano-deploy/unicorn.rb
+++ b/lib/capistrano-deploy/unicorn.rb
@@ -2,7 +2,8 @@ module CapistranoDeploy
   module Unicorn
     def self.load_into(configuration)
       configuration.load do
-        set(:unicorn_pid) { "`cat #{deploy_to}/tmp/pids/unicorn.pid`" }
+        set(:unicorn_pid_file) { "#{deploy_to}/tmp/pids/unicorn.pid" }
+        set(:unicorn_pid) { "$(cat #{unicorn_pid_file}" }
 
         namespace :unicorn do
           desc 'Reload unicorn'
@@ -17,7 +18,7 @@ module CapistranoDeploy
 
           desc 'Reexecute unicorn'
           task :reexec, :roles => :app, :except => {:no_release => true} do
-            run "kill -USR2 #{unicorn_pid}"
+            run "[[ -e #{unicorn_pid_file} ]]; then kill -USR2 #{unicorn_pid}; fi"
           end
         end
       end


### PR DESCRIPTION
- This prevents unicorn:reexec from failing if the pid file doesn't
  exist. This fixes an issue we have on initial deployment where are
  pid file hasn't been created yet.
- This also allows the pid file to be configurable.
- Using newer $(command) style of command substitution instead of
  backticks: http://tldp.org/LDP/Bash-Beginners-Guide/html/sect_03_04.html
